### PR TITLE
Fix ul/ol markup for extra-small resolution devices

### DIFF
--- a/frontend/static/css/posts.css
+++ b/frontend/static/css/posts.css
@@ -105,7 +105,7 @@
         padding-left: 35px;
         width: 95%;
         max-width: 800px;
-        min-width: 300px;
+        min-width: min(300px, 95%);
         padding-bottom: 1.2em;
         font-weight: 400;
         font-style: normal;


### PR DESCRIPTION
## TL;DR
Привет, вчера читал посты про Японию и Берлин и естественно жадно читал комменты. 
В комментах пацаны и пацанессы любят доказывать свою точку зрения приводя аргументы с помощью списков, которые плохо отображаются на моём телефоне, съедая часть контента.

Это маленький фикс разметки, чтобы у ребят на телефонах с маленьким разрешением вьюпорта (у меня iPhone XS 375x812) тоже всё было хорошо и можно было читать токсичные и не очень комментарии :)
Задевает не только списки в комментах, а вообще все, но с обычными списками проблемы не было, так что просто ничего не изменится для них.

### Changes

До(скрины с телефона):
![IMAGE 2023-08-27 13:18:18](https://github.com/vas3k/vas3k.blog/assets/15385798/3b7e4139-b264-4334-8fcc-4c91edb38ed4)
![IMAGE 2023-08-27 13:18:22](https://github.com/vas3k/vas3k.blog/assets/15385798/03a1a062-ab5a-4a83-812f-4c0693b27619)

После:
<img width="515" alt="image" src="https://github.com/vas3k/vas3k.blog/assets/15385798/827b0b95-6d0c-4081-907c-2ed8493edda7">
