### PR TITLE
fix: inherit headline date color for dark mode

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -314,7 +314,6 @@
 
     .simple-headline-date {
         font-size: 90%;
-        color: #333;
     }
 
     .simple-headline-title,


### PR DESCRIPTION
### Problem  
In dark mode, the date in notes is not visible (e.g., [this note](https://vas3k.blog/notes/indie_vs_corpo/)).  

### What was done  
Removed the override for the _headline date_ color so that it inherits from the parent (`body`). In light mode, it will remain `#333`, while in dark mode, it will now be `#DDD`.  

<img width="1453" alt="Screenshot 2025-02-09 at 23 09 22" src="https://github.com/user-attachments/assets/3ad19b03-4092-499f-a450-6f6e953a4cf0" />
